### PR TITLE
PyLops Interface

### DIFF
--- a/occamypy/__init__.py
+++ b/occamypy/__init__.py
@@ -10,3 +10,5 @@ from .torch import *
 
 if CUPY_ENABLED:
     from .cupy import *
+
+from .numpy.operator import pylops_interface

--- a/occamypy/numpy/operator/pylops_interface.py
+++ b/occamypy/numpy/operator/pylops_interface.py
@@ -1,0 +1,86 @@
+import numpy as np
+from occamypy import Operator
+
+try:
+    import pylops
+except ImportError:
+    raise UserWarning("PyLops is not installed. To use this feature please run: pip install pylops")
+
+__all__ = [
+    "ToPylops",
+    "FromPylops",
+]
+
+
+class FromPylops(Operator):
+    
+    def __init__(self, domain, range, op):
+        """
+        Cast a pylops LinearOperator to Operator
+        """
+        if not isinstance(op, pylops.LinearOperator):
+            raise TypeError("op has to be a pylops.LinearOperator")
+        if op.shape[0] != range.size:
+            raise ValueError("Range and operator rows mismatch")
+        if op.shape[1] != domain.size:
+            raise ValueError("Domain and operator columns mismatch")
+        
+        self.name = op.__str__()
+        self.op = op
+        
+        super(FromPylops, self).__init__(domain, range)
+    
+    def __str__(self):
+        return self.name.replace("<", "").replace(">", "")
+    
+    def forward(self, add, model, data):
+        self.checkDomainRange(model, data)
+        if not add:
+            data.zero()
+        x = model.getNdArray().ravel()
+        y = self.op.matvec(x)
+        data.getNdArray()[:] += y.reshape(data.shape)
+        return
+    
+    def adjoint(self, add, model, data):
+        self.checkDomainRange(model, data)
+        if not add:
+            model.zero()
+        y = data.getNdArray().ravel()
+        x = self.op.rmatvec(y)
+        model.getNdArray()[:] += x.reshape(model.shape)
+        return
+
+
+class ToPylops(pylops.LinearOperator):
+    
+    def __init__(self, op: Operator):
+        """
+        Cast an in-core Operator to pylops.LinearOperator
+        :param op: `occamypy.Operator` object (or child)
+        """
+        super(ToPylops, self).__init__(explicit=False)
+        self.shape = (op.range.size, op.domain.size)
+        self.dtype = op.domain.getNdArray().dtype
+        
+        if not isinstance(op, Operator):
+            raise TypeError("op has to be an Operator")
+        self.op = op
+        
+        # these are just temporary vectors, used by forward and adjoint computations
+        self.domain = op.domain.clone()
+        self.range = op.range.clone()
+    
+    def _matvec(self, x: np.ndarray) -> np.ndarray:
+        x_ = self.domain.clone()
+        x_[:] = x.reshape(self.domain.shape).astype(self.dtype)
+        y_ = self.range.clone()
+        self.op.forward(False, x_, y_)
+        return y_.getNdArray().ravel()
+    
+    def _rmatvec(self, y: np.ndarray) -> np.ndarray:
+        y_ = self.range.clone()
+        y_[:] = y.reshape(self.range.shape).astype(self.dtype)
+        x_ = self.domain.clone()
+        self.op.adjoint(False, x_, y_)
+        return x_.getNdArray().ravel()

--- a/occamypy/numpy/vector.py
+++ b/occamypy/numpy/vector.py
@@ -17,8 +17,8 @@ class VectorNumpy(Vector):
         if isinstance(in_content, str):  # Header file name passed to constructor
             self.arr = np.load(in_content, allow_pickle=True)
         elif isinstance(in_content, np.ndarray):  # Numpy array passed to constructor
-            if np.isfortran(in_content):
-                raise TypeError('Input array not a C contiguous array!')
+            # if np.isfortran(in_content):  # for seplib compatibility
+            #     raise TypeError('Input array not a C contiguous array!')
             self.arr = np.array(in_content, copy=False)
             self.ax_info = None
         elif isinstance(in_content, tuple):  # Tuple size passed to constructor

--- a/occamypy/operator/derivative.py
+++ b/occamypy/operator/derivative.py
@@ -257,21 +257,23 @@ class Gradient(Operator):
     def adjoint(self, add, model, data):
         return self.op.adjoint(add, model, data)
     
-    def merge_directions(self, add, model, data, iso=True):
+    def merge_directions(self, grad_vector, iso=True):
         """
         Merge the different directional contributes, using the L2 norm (iso=True) or the simple sum (iso=False)
         """
-        self.range.checkSame(model)
-        if not add:
-            data.zero()
+        self.range.checkSame(grad_vector)
+        
+        data = self.domain.clone()
         
         if iso:
-            for v in model.vecs:
+            for v in grad_vector.vecs:
                 data.scaleAdd(v.clone().pow(2), 1., 1.)
                 data.pow(.5)
         else:
-            for v in model.vecs:
+            for v in grad_vector.vecs:
                 data.scaleAdd(v, 1., 1.)
+        
+        return data
 
 
 class Laplacian(Operator):

--- a/tutorials/pylops_interface.py
+++ b/tutorials/pylops_interface.py
@@ -1,0 +1,164 @@
+import numpy as np
+import occamypy as o
+import matplotlib.pyplot as plt
+import pylops
+
+
+if __name__ == '__main__':
+    
+    shape = (3, 5)
+    x = o.VectorNumpy(shape).set(1.)
+    
+    # test FromPylops
+    d = np.arange(x.size)
+    D = o.pylops_interface.FromPylops(x, x, pylops.Diagonal(d))
+    D.dotTest(True)
+    
+    # test ToPylops
+    S = o.pylops_interface.ToPylops(o.Scaling(x, 2.))
+    pylops.utils.dottest(S, x.size, x.size, tol=1e-6, complexflag=0, verb=True)
+    print("\t", np.isclose((S * x.arr.ravel()).reshape(x.shape), 2. * x.arr).all())
+    
+    ####################################################################################################################
+    # interesting pylops example
+    # https://pylops.readthedocs.io/en/latest/tutorials/ctscan.html#sphx-glr-tutorials-ctscan-py
+    def radoncurve(x, r, theta):
+        return (r - ny // 2) / (np.sin(np.deg2rad(theta)) + 1e-15) + np.tan(np.deg2rad(90 - theta)) * x + ny // 2
+    
+    
+    x = np.load('data/shepp_logan_phantom.npy').T
+    x = x / x.max()
+    nx, ny = x.shape
+    
+    ntheta = 150
+    theta = np.linspace(0., 180., ntheta, endpoint=False)
+    
+    RLop = pylops.signalprocessing.Radon2D(np.arange(ny), np.arange(nx),
+                                           theta, kind=radoncurve,
+                                           centeredh=True, interp=False,
+                                           engine='numpy', dtype='float64')
+    
+    y = RLop.H * x.ravel()
+    y = y.reshape(ntheta, ny)
+    
+    xrec = RLop * y.ravel()
+    xrec = xrec.reshape(nx, ny)
+    
+    fig, axs = plt.subplots(1, 3, figsize=(10, 4))
+    axs[0].imshow(x.T, vmin=0, vmax=1, cmap='gray')
+    axs[0].set_title('Model')
+    axs[0].axis('tight')
+    axs[1].imshow(y.T, cmap='gray')
+    axs[1].set_title('Data')
+    axs[1].axis('tight')
+    axs[2].imshow(xrec.T, cmap='gray')
+    axs[2].set_title('Adjoint model')
+    axs[2].axis('tight')
+    fig.tight_layout()
+    plt.show()
+    
+    x_ = o.VectorNumpy(x)
+    y_ = o.VectorNumpy((ntheta, ny))
+    R_ = o.pylops_interface.FromPylops(x_, y_, RLop.H)
+    y_ = R_ * x_
+    xrec_ = R_.H * y_
+    
+    fig, axs = plt.subplots(1, 3, figsize=(10, 4))
+    axs[0].imshow(x_.plot().T, vmin=0, vmax=1, cmap='gray')
+    axs[0].set_title('Model')
+    axs[0].axis('tight')
+    axs[1].imshow(y_.plot().T, cmap='gray')
+    axs[1].set_title('Data')
+    axs[1].axis('tight')
+    axs[2].imshow(xrec_.plot().T, cmap='gray')
+    axs[2].set_title('Adjoint model')
+    axs[2].axis('tight')
+    fig.tight_layout()
+    plt.show()
+    
+    # TV inversion
+    G = o.Gradient(x_, stencil="backward")
+    
+    # same of PyLops tutorial
+    mu = 1.5
+    lamda = [1.0, 1.0]
+    niter = 3
+    niterinner = 4
+    
+    problemTV = o.GeneralizedLasso(x_.clone().zero(), y_, R_, eps=lamda[0] / mu, reg=G)
+    
+    SB = o.SplitBregman(o.BasicStopper(niter=niter), niter_inner=niterinner, niter_solver=20,
+                        linear_solver="LSQR", warm_start=True)
+    
+    SB.setDefaults(save_obj=True)
+    SB.run(problemTV, verbose=True, inner_verbose=False)
+    
+    fig, axs = plt.subplots(1, 3, figsize=(10, 4))
+    axs[0].imshow(x_.plot().T, vmin=0, vmax=1, cmap='gray')
+    axs[0].set_title('Model')
+    axs[0].axis('tight')
+    axs[1].imshow(problemTV.model.plot().T, vmin=0, vmax=1, cmap='gray')
+    axs[1].set_title('Inverted model')
+    axs[1].axis('tight')
+    fig.tight_layout()
+    plt.show()
+    
+    ####################################################################################################################
+    # now with dask
+    client = o.dask.DaskClient(local_params={"processes": True}, n_wrks=4)
+    print("Number of workers = %d" % client.getNworkers())
+    print("Workers Ids = %s" % client.getWorkerIds())
+    
+    vec = o.VectorNumpy(np.load('data/shepp_logan_phantom.npy').T * 1.).scale(1 / 255)
+    
+    # # method 1: instantiate a vector template and spread it using the chunk parameter
+    # this creates one copy of the vector on each worker, for each chunk.
+    # e.g., here we have 4 workers, with 2,3,5,10 copies each.
+    # verify that vec_.vecDask[0].result().checkSame(vec_.vecDask[1].result())
+    v1 = o.dask.DaskVector(client,
+                           vector_template=vec,
+                           chunks=(2, 3, 5, 10))
+    
+    # # method 2: instantiate multiple vectors and spreading them to the given workers
+    # this is useful for distibuting large vectors
+    v2 = o.dask.DaskVector(client,
+                           vectors=[o.VectorNumpy(vec[:50]),
+                                    o.VectorNumpy(vec[50:100]),
+                                    o.VectorNumpy(vec[100:150]),
+                                    o.VectorNumpy(vec[150:])],
+                           chunks=(1, 1, 1, 1))
+    
+    # Collect such a dask vector to a in-core vector
+    Collect = o.dask.DaskCollect(v2, vec)
+    v2c = Collect * v2
+    vec.checkSame(v2c)
+    
+    # method 3: use a Spread operator to distribute a vector...
+    Spread = o.dask.DaskSpread(client, vec, [1] * client.getNworkers())
+    v3 = Spread * vec
+    # ...and to get it back
+    pippo = Spread.T * v3
+    pippo.checkSame(vec)
+    
+    # Pylops To DaskOperator, leveraging FromPylops.
+    D1 = o.dask.DaskOperator(
+        client,
+        o.pylops_interface.FromPylops,
+        [(v, v, pylops.FirstDerivative(np.prod(shape))) for v, shape in zip(v1.vecDask, v1.shape)],
+        v1.chunks)
+    D1.dotTest(True)
+    
+    D2 = o.dask.DaskOperator(
+        client,
+        o.pylops_interface.FromPylops,
+        [(v, v, pylops.FirstDerivative(np.prod(shape))) for v, shape in zip(v2.vecDask, v2.shape)],
+        v2.chunks)
+    D2.dotTest(True)
+    D3 = o.dask.DaskOperator(
+        client,
+        o.pylops_interface.FromPylops,
+        [(v, v, pylops.FirstDerivative(np.prod(shape))) for v, shape in zip(v3.vecDask, v3.shape)],
+        Spread.chunks)
+    D3.dotTest(True)
+    
+    print("end of script")


### PR DESCRIPTION
I've added a numpy operator submodule named `pylops_interface`, which contains two new classes: `FromPylops` and `ToPylops`. They are meant to enable the joint usage of OccamyPy  and [PyLops](https://pylops.readthedocs.io/en/stable/), e.g. using already-implemented operators/algorithms and so on.
Please, check `tutorials/pylops_interface.py` for usage examples. We can consider creating a notebook out of these examples, or possibly add a more significant example.